### PR TITLE
add Codeium version in widget tooltip

### DIFF
--- a/src/main/kotlin/com/codeium/intellij/statusbar/CodeiumWidget.kt
+++ b/src/main/kotlin/com/codeium/intellij/statusbar/CodeiumWidget.kt
@@ -41,7 +41,7 @@ class CodeiumWidget(project: Project) : EditorBasedStatusBarPopup(project, false
     val state = service<CodeiumStatusService>().getState()
     val tooltipText =
         if (state?.message.isNullOrEmpty()) {
-          "Codeium"
+          "Codeium " +  service<CodeiumStatusService>().getVersion()
         } else {
           state?.message!!
         }


### PR DESCRIPTION
Include the version number in the tooltip overlay within the status bar, eliminating the need for me to repeatedly check the plugin page.